### PR TITLE
Misc improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 example
+Dockerfile
 .github
 .idea
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Build the go application into a binary
 FROM golang:alpine as builder
-WORKDIR /app
-ADD . ./
-RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -installsuffix cgo -o gatus .
 RUN apk --update add ca-certificates
+WORKDIR /app
+COPY . ./
+RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -installsuffix cgo -o gatus .
 
 # Run Tests inside docker image if you don't have a configured go environment
 #RUN apk update && apk add --virtual build-dependencies build-base gcc


### PR DESCRIPTION
improving build caching, use COPY instead of ADD

  - adding `Dockerfile` and `.git/` to `.dockeringore` improves
    caching when building images when these paths have changes
    unrelated to application functionality
  - using COPY instead of ADD, since working with local paths, and
    not extracting archived data
  - installing packages before building application binary improves caching,
    and avoids installing packages every time the application code changes