### PR TITLE
add parameterization for host and port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin
 .idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Note that you can also add environment variables in the configuration file (i.e.
 | `security.basic.username`                | Username for Basic authentication                                             | Required `""`  |
 | `security.basic.password-sha512`         | Password's SHA512 hash for Basic authentication                               | Required `""`  |
 | `disable-monitoring-lock`                | Whether to [disable the monitoring lock](#disable-monitoring-lock)            | `false`        |
+| `web.address`                            | Address to listen on                                                          | `0.0.0.0`      |
+| `web.port`                               | Port to listen on                                                             | `8080`         |
 
 For Kubernetes configuration, see [Kubernetes](#kubernetes-alpha)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -262,11 +262,11 @@ services:
 	}
 
 	if config.Web.Address != DefaultAddress {
-		t.Errorf("Bind address should have been %s, because it is specified in config", DefaultAddress)
+		t.Errorf("Bind address should have been %s, because it is the default value", DefaultAddress)
 	}
 
 	if config.Web.Port != DefaultPort {
-		t.Errorf("Port should have been %d, because it is specified in config", DefaultPort)
+		t.Errorf("Port should have been %d, because it is the default value", DefaultPort)
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -219,6 +219,23 @@ services:
 	}
 }
 
+func TestParseAndValidateConfigBytesWithInvalidPort(t *testing.T) {
+	defer func() { recover() }()
+
+	parseAndValidateConfigBytes([]byte(`
+web:
+  port: 65536
+  address: 127.0.0.1
+services:
+  - name: twinnation
+    url: https://twinnation.org/actuator/health
+    conditions:
+      - "[STATUS] == 200"
+`))
+
+	t.Fatal("Should've panicked because the configuration specifies an invalid port value")
+}
+
 func TestParseAndValidateConfigBytesWithMetrics(t *testing.T) {
 	config, err := parseAndValidateConfigBytes([]byte(`
 metrics: true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -103,6 +103,120 @@ services:
 	if config.Services[0].Interval != 60*time.Second {
 		t.Errorf("Interval should have been %s, because it is the default value", 60*time.Second)
 	}
+
+	if config.Web.Address != DefaultAddress {
+		t.Errorf("Bind address should have been %s, because it is the default value", DefaultAddress)
+	}
+
+	if config.Web.Port != DefaultPort {
+		t.Errorf("Port should have been %d, because it is the default value", DefaultPort)
+	}
+}
+
+func TestParseAndValidateConfigBytesWithAddress(t *testing.T) {
+	config, err := parseAndValidateConfigBytes([]byte(`
+web:
+  address: 127.0.0.1
+services:
+  - name: twinnation
+    url: https://twinnation.org/actuator/health
+    conditions:
+      - "[STATUS] == 200"
+`))
+	if err != nil {
+		t.Error("No error should've been returned")
+	}
+	if config == nil {
+		t.Fatal("Config shouldn't have been nil")
+	}
+	if config.Metrics {
+		t.Error("Metrics should've been false by default")
+	}
+	if config.Services[0].URL != "https://twinnation.org/actuator/health" {
+		t.Errorf("URL should have been %s", "https://twinnation.org/actuator/health")
+	}
+	if config.Services[0].Interval != 60*time.Second {
+		t.Errorf("Interval should have been %s, because it is the default value", 60*time.Second)
+	}
+
+	if config.Web.Address != "127.0.0.1" {
+		t.Errorf("Bind address should have been %s, because it is specified in config", "127.0.0.1")
+	}
+
+	if config.Web.Port != DefaultPort {
+		t.Errorf("Port should have been %d, because it is the default value", DefaultPort)
+	}
+}
+
+func TestParseAndValidateConfigBytesWithPort(t *testing.T) {
+	config, err := parseAndValidateConfigBytes([]byte(`
+web:
+  port: 12345
+services:
+  - name: twinnation
+    url: https://twinnation.org/actuator/health
+    conditions:
+      - "[STATUS] == 200"
+`))
+	if err != nil {
+		t.Error("No error should've been returned")
+	}
+	if config == nil {
+		t.Fatal("Config shouldn't have been nil")
+	}
+	if config.Metrics {
+		t.Error("Metrics should've been false by default")
+	}
+	if config.Services[0].URL != "https://twinnation.org/actuator/health" {
+		t.Errorf("URL should have been %s", "https://twinnation.org/actuator/health")
+	}
+	if config.Services[0].Interval != 60*time.Second {
+		t.Errorf("Interval should have been %s, because it is the default value", 60*time.Second)
+	}
+
+	if config.Web.Address != DefaultAddress {
+		t.Errorf("Bind address should have been %s, because it is the default value", DefaultAddress)
+	}
+
+	if config.Web.Port != 12345 {
+		t.Errorf("Port should have been %d, because it is specified in config", 12345)
+	}
+}
+
+func TestParseAndValidateConfigBytesWithPortAndHost(t *testing.T) {
+	config, err := parseAndValidateConfigBytes([]byte(`
+web:
+  port: 12345
+  address: 127.0.0.1
+services:
+  - name: twinnation
+    url: https://twinnation.org/actuator/health
+    conditions:
+      - "[STATUS] == 200"
+`))
+	if err != nil {
+		t.Error("No error should've been returned")
+	}
+	if config == nil {
+		t.Fatal("Config shouldn't have been nil")
+	}
+	if config.Metrics {
+		t.Error("Metrics should've been false by default")
+	}
+	if config.Services[0].URL != "https://twinnation.org/actuator/health" {
+		t.Errorf("URL should have been %s", "https://twinnation.org/actuator/health")
+	}
+	if config.Services[0].Interval != 60*time.Second {
+		t.Errorf("Interval should have been %s, because it is the default value", 60*time.Second)
+	}
+
+	if config.Web.Address != "127.0.0.1" {
+		t.Errorf("Bind address should have been %s, because it is specified in config", "127.0.0.1")
+	}
+
+	if config.Web.Port != 12345 {
+		t.Errorf("Port should have been %d, because it is specified in config", 12345)
+	}
 }
 
 func TestParseAndValidateConfigBytesWithMetrics(t *testing.T) {
@@ -128,6 +242,51 @@ services:
 	}
 	if config.Services[0].Interval != 60*time.Second {
 		t.Errorf("Interval should have been %s, because it is the default value", 60*time.Second)
+	}
+
+	if config.Web.Address != DefaultAddress {
+		t.Errorf("Bind address should have been %s, because it is specified in config", DefaultAddress)
+	}
+
+	if config.Web.Port != DefaultPort {
+		t.Errorf("Port should have been %d, because it is specified in config", DefaultPort)
+	}
+}
+
+func TestParseAndValidateConfigBytesWithMetricsAndHostAndPort(t *testing.T) {
+	config, err := parseAndValidateConfigBytes([]byte(`
+metrics: true
+services:
+  - name: twinnation
+    url: https://twinnation.org/actuator/health
+    conditions:
+      - "[STATUS] == 200"
+web:
+  address: 192.168.0.1
+  port: 9090
+`))
+	if err != nil {
+		t.Error("No error should've been returned")
+	}
+	if config == nil {
+		t.Fatal("Config shouldn't have been nil")
+	}
+	if !config.Metrics {
+		t.Error("Metrics should have been true")
+	}
+	if config.Services[0].URL != "https://twinnation.org/actuator/health" {
+		t.Errorf("URL should have been %s", "https://twinnation.org/actuator/health")
+	}
+	if config.Services[0].Interval != 60*time.Second {
+		t.Errorf("Interval should have been %s, because it is the default value", 60*time.Second)
+	}
+
+	if config.Web.Address != "192.168.0.1" {
+		t.Errorf("Bind address should have been %s, because it is the default value", "192.168.0.1")
+	}
+
+	if config.Web.Port != 9090 {
+		t.Errorf("Port should have been %d, because it is specified in config", 9090)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -24,37 +23,7 @@ var (
 	cachedServiceResults          []byte
 	cachedServiceResultsGzipped   []byte
 	cachedServiceResultsTimestamp time.Time
-	port                          int
-	host                          string
 )
-
-func init() {
-	// Customizing priority:
-	// (1) command line parameters will be preferred over
-	// (2) environment variables will be preferred over
-	// (3) application defaults
-
-	// set defaults for the case that neither an environment variable nor a
-	// command line parameter is passed
-	var defaultHost = ""
-	var defaultPort = 8080
-
-	// assume set if the is a valid port number
-	if p, err := strconv.Atoi(os.Getenv("GATUS_CONFIG_PORT")); err == nil && p > 0 {
-		defaultPort = p
-	}
-
-	// explicitly asked if the user has set a the environment variable to
-	// blank / empty in order to allow listening on all interfaces
-	if h, set := os.LookupEnv("GATUS_CONFIG_HOST"); set == true {
-		defaultHost = h
-	}
-
-	flag.IntVar(&port, "port", defaultPort, "port to listen (default: 8080)")
-	flag.IntVar(&port, "p", defaultPort, "port to listen (default: 8080 ; shorthand)")
-	flag.StringVar(&host, "host", defaultHost, "host to listen on (default all interfaces on host)")
-	flag.StringVar(&host, "h", defaultHost, "host to listen on (default all interfaces on host; shorthand)")
-}
 
 func main() {
 	flag.Parse()
@@ -71,9 +40,9 @@ func main() {
 		http.Handle("/metrics", promhttp.Handler())
 	}
 
-	log.Printf("[main][main] Listening on %s:%d", host, port)
+	log.Printf("[main][main] Listening on %s:%d\r\n", cfg.Web.Address, cfg.Web.Port)
 	go watchdog.Monitor(cfg)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%d", host, port), nil))
+	log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%d", cfg.Web.Address, cfg.Web.Port), nil))
 }
 
 func loadConfiguration() *config.Config {

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"compress/gzip"
-	"flag"
 	"fmt"
 	"log"
 	"net/http"
@@ -26,8 +25,6 @@ var (
 )
 
 func main() {
-	flag.Parse()
-
 	cfg := loadConfiguration()
 	resultsHandler := serviceResultsHandler
 	if cfg.Security != nil && cfg.Security.IsValid() {

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func init() {
 	flag.IntVar(&port, "port", defaultPort, "port to listen (default: 8080)")
 	flag.IntVar(&port, "p", defaultPort, "port to listen (default: 8080 ; shorthand)")
 	flag.StringVar(&host, "host", defaultHost, "host to listen on (default all interfaces on host)")
-	flag.StringVar(&host, "host", defaultHost, "host to listen on (default all interfaces on host; shorthand)")
+	flag.StringVar(&host, "h", defaultHost, "host to listen on (default all interfaces on host; shorthand)")
 }
 
 func main() {


### PR DESCRIPTION
Host and port can be specified by either a environment variable or a
dedicated command line parameter. Command line parameters will be preferred
over environment variables, which will be preferred over the application
defaults.

addresses #40 