### PR TITLE
Feature/context root

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Note that you can also add environment variables in the configuration file (i.e.
 | `disable-monitoring-lock`                | Whether to [disable the monitoring lock](#disable-monitoring-lock)            | `false`        |
 | `web.address`                            | Address to listen on                                                          | `0.0.0.0`      |
 | `web.port`                               | Port to listen on                                                             | `8080`         |
+| `web.context-root`                       | Context root which should be used by the web frontent                         | `/`            |
 
 For Kubernetes configuration, see [Kubernetes](#kubernetes-alpha)
 

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,9 @@ const (
 
 	// DefaultPort is the default port the service will listen on
 	DefaultPort = 8080
+
+	// DefaultContextRoot is the default context root of the web application
+	DefaultContextRoot = "/"
 )
 
 var (

--- a/config/config.go
+++ b/config/config.go
@@ -146,7 +146,7 @@ func parseAndValidateConfigBytes(yamlBytes []byte) (config *Config, err error) {
 
 func validateWebConfig(config *Config) {
 	if config.Web == nil {
-		config.Web = &webConfig{Address: DefaultAddress, Port: DefaultPort}
+		config.Web = &webConfig{Address: DefaultAddress, Port: DefaultPort, ContextRoot: DefaultContextRoot}
 	} else {
 		config.Web.validateAndSetDefaults()
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -109,6 +109,9 @@ services:
 	if config.Web.Port != DefaultPort {
 		t.Errorf("Port should have been %d, because it is the default value", DefaultPort)
 	}
+	if config.Web.ContextRoot != DefaultContextRoot {
+		t.Errorf("ContextRoot should have been %s, because it is the default value", DefaultContextRoot)
+	}
 }
 
 func TestParseAndValidateConfigBytesWithAddress(t *testing.T) {
@@ -215,6 +218,44 @@ services:
 	}
 }
 
+func TestParseAndValidateConfigBytesWithPortAndHostAndContextRoot(t *testing.T) {
+	config, err := parseAndValidateConfigBytes([]byte(`
+web:
+  port: 12345
+  address: 127.0.0.1
+  context-root: /deeply/nested/down=/their
+services:
+  - name: twinnation
+    url: https://twinnation.org/health
+    conditions:
+      - "[STATUS] == 200"
+`))
+	if err != nil {
+		t.Error("No error should've been returned")
+	}
+	if config == nil {
+		t.Fatal("Config shouldn't have been nil")
+	}
+	if config.Metrics {
+		t.Error("Metrics should've been false by default")
+	}
+	if config.Services[0].URL != "https://twinnation.org/health" {
+		t.Errorf("URL should have been %s", "https://twinnation.org/health")
+	}
+	if config.Services[0].Interval != 60*time.Second {
+		t.Errorf("Interval should have been %s, because it is the default value", 60*time.Second)
+	}
+	if config.Web.Address != "127.0.0.1" {
+		t.Errorf("Bind address should have been %s, because it is specified in config", "127.0.0.1")
+	}
+	if config.Web.Port != 12345 {
+		t.Errorf("Port should have been %d, because it is specified in config", 12345)
+	}
+	if config.Web.ContextRoot != "/deeply/nested/down=/their/" {
+		t.Errorf("Port should have been %s, because it is specified in config", "/deeply/nested/down=/their/")
+	}
+}
+
 func TestParseAndValidateConfigBytesWithInvalidPort(t *testing.T) {
 	defer func() { recover() }()
 	_, _ = parseAndValidateConfigBytes([]byte(`
@@ -259,6 +300,9 @@ services:
 	}
 	if config.Web.Port != DefaultPort {
 		t.Errorf("Port should have been %d, because it is the default value", DefaultPort)
+	}
+	if config.Web.ContextRoot != DefaultContextRoot {
+		t.Errorf("ContextRoot should have been %s, because it is the default value", DefaultContextRoot)
 	}
 }
 

--- a/config/web.go
+++ b/config/web.go
@@ -21,7 +21,7 @@ type webConfig struct {
 }
 
 // validateAndSetDefaults checks and sets missing values based on the defaults
-// in given in DefaultAddress and DefaultPort if necessary
+// in given in DefaultWebContext, DefaultAddress and DefaultPort if necessary
 func (web *webConfig) validateAndSetDefaults() {
 	if len(web.Address) == 0 {
 		web.Address = DefaultAddress
@@ -31,17 +31,27 @@ func (web *webConfig) validateAndSetDefaults() {
 	} else if web.Port < 0 || web.Port > math.MaxUint16 {
 		panic(fmt.Sprintf("port has an invalid: value should be between %d and %d", 0, math.MaxUint16))
 	}
-	if len(web.ContextRoot) == 0 {
-		web.ContextRoot = DefaultContextRoot
+
+	web.ContextRoot = validateAndBuild(web.ContextRoot)
+}
+
+// validateAndBuild validates and builds a checked
+// path for the context root
+func validateAndBuild(contextRoot string) string {
+	trimedContextRoot := strings.Trim(contextRoot, "/")
+
+	if len(trimedContextRoot) == 0 {
+		return DefaultContextRoot
 	} else {
-		url, err := url.Parse(web.ContextRoot)
+		url, err := url.Parse(trimedContextRoot)
 		if err != nil {
-			panic(fmt.Sprintf("Invalid context root %s - error: %s.", web.ContextRoot, err))
+			panic(fmt.Sprintf("Invalid context root %s - error: %s.", contextRoot, err))
 		}
-		if url.Path != web.ContextRoot {
-			panic(fmt.Sprintf("Invalid context root %s, simple path required.", web.ContextRoot))
+		if url.Path != trimedContextRoot {
+			panic(fmt.Sprintf("Invalid context root %s, simple path required.", contextRoot))
 		}
-		web.ContextRoot = strings.TrimRight(url.Path, "/") + "/"
+
+		return "/" + strings.Trim(url.Path, "/") + "/"
 	}
 }
 

--- a/config/web.go
+++ b/config/web.go
@@ -60,9 +60,9 @@ func (web *webConfig) SocketAddress() string {
 	return fmt.Sprintf("%s:%d", web.Address, web.Port)
 }
 
-// AppendToContexRoot appends the given string to the context root
-// AppendToContexRoot takes care of having only one "/" character at
+// PrependWithContextRoot appends the given string to the context root
+// PrependWithContextRoot takes care of having only one "/" character at
 // the join point and exactly on "/" at the end
-func (web *webConfig) AppendToContexRoot(fragment string) string {
+func (web *webConfig) PrependWithContextRoot(fragment string) string {
 	return web.ContextRoot + strings.Trim(fragment, "/") + "/"
 }

--- a/config/web.go
+++ b/config/web.go
@@ -3,6 +3,8 @@ package config
 import (
 	"fmt"
 	"math"
+	"net/url"
+	"strings"
 )
 
 // webConfig is the structure which supports the configuration of the endpoint
@@ -13,6 +15,10 @@ type webConfig struct {
 
 	// Port to listen on (default to 8080 specified by DefaultPort)
 	Port int `yaml:"port"`
+
+	ContextRoot string `yaml:"context-root"`
+
+	safeContextRoot string
 }
 
 // validateAndSetDefaults checks and sets missing values based on the defaults
@@ -26,9 +32,43 @@ func (web *webConfig) validateAndSetDefaults() {
 	} else if web.Port < 0 || web.Port > math.MaxUint16 {
 		panic(fmt.Sprintf("port has an invalid: value should be between %d and %d", 0, math.MaxUint16))
 	}
+	if len(web.ContextRoot) == 0 {
+		web.safeContextRoot = DefaultContextRoot
+	} else {
+		// url.PathEscape escapes all "/", in order to build a secure path
+		// (1) split into path fragements using "/" as delimiter
+		// (2) use url.PathEscape() on each fragment
+		// (3) re-concatinate the path using "/" as join character
+		const splitJoinChar = "/"
+		pathes := strings.Split(web.ContextRoot, splitJoinChar)
+		escapedPathes := make([]string, len(pathes))
+		for i, path := range pathes {
+			escapedPathes[i] = url.PathEscape(path)
+		}
+
+		web.safeContextRoot = strings.Join(escapedPathes, splitJoinChar)
+
+		// assure that we have still a valid url
+		_, err := url.Parse(web.safeContextRoot)
+		if err != nil {
+			panic(fmt.Sprintf("Invalid context root %s - Error %s", web.ContextRoot, err))
+		}
+	}
 }
 
 // SocketAddress returns the combination of the Address and the Port
 func (web *webConfig) SocketAddress() string {
 	return fmt.Sprintf("%s:%d", web.Address, web.Port)
+}
+
+// CtxRoot returns the context root
+func (web *webConfig) CtxRoot() string {
+	return web.safeContextRoot
+}
+
+// AppendToCtxRoot appends the given string to the context root
+// AppendToCtxRoot takes care of having only one "/" character at
+// the join point and exactly on "/" at the end
+func (web *webConfig) AppendToCtxRoot(fragment string) string {
+	return strings.TrimSuffix(web.safeContextRoot, "/") + "/" + strings.Trim(fragment, "/") + "/"
 }

--- a/config/web_test.go
+++ b/config/web_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestWebConfig_SocketAddress(t *testing.T) {
 	web := &webConfig{
@@ -50,6 +53,18 @@ func TestWebConfig_ContextRootInvalid(t *testing.T) {
 	web.validateAndSetDefaults()
 
 	t.Fatal("Should've panicked because the configuration specifies an invalid context root")
+}
+
+func TestWebConfig_ContextRootNonParseable(t *testing.T) {
+	defer func() { recover() }()
+
+	web := &webConfig{
+		ContextRoot: "/invalid" + string([]byte{0x7F}) + "/",
+	}
+
+	web.validateAndSetDefaults()
+
+	t.Fatal(fmt.Sprintf("Should've panicked because the configuration specifies an invalid context root %s", web.ContextRoot))
 }
 
 func TestWebConfig_ContextRootMultiPath(t *testing.T) {

--- a/config/web_test.go
+++ b/config/web_test.go
@@ -12,6 +12,20 @@ func TestWebConfig_SocketAddress(t *testing.T) {
 	}
 }
 
+func TestWebConfig_ContextRootEmpty(t *testing.T) {
+	const expected = "/"
+
+	web := &webConfig{
+		ContextRoot: "",
+	}
+
+	web.validateAndSetDefaults()
+
+	if web.ContextRoot != expected {
+		t.Errorf("expected %s, got %s", expected, web.ContextRoot)
+	}
+}
+
 func TestWebConfig_ContextRoot(t *testing.T) {
 	const expected = "/status/"
 
@@ -21,13 +35,13 @@ func TestWebConfig_ContextRoot(t *testing.T) {
 
 	web.validateAndSetDefaults()
 
-	if web.CtxRoot() != expected {
-		t.Errorf("expected %s, got %s", expected, web.CtxRoot())
+	if web.ContextRoot != expected {
+		t.Errorf("expected %s, got %s", expected, web.ContextRoot)
 	}
 }
 
-func TestWebConfig_ContextRootWithEscapableChars(t *testing.T) {
-	const expected = "/s%3F=ta%20t%20u&s/"
+func TestWebConfig_ContextRootInvalid(t *testing.T) {
+	defer func() { recover() }()
 
 	web := &webConfig{
 		ContextRoot: "/s?=ta t u&s/",
@@ -35,21 +49,19 @@ func TestWebConfig_ContextRootWithEscapableChars(t *testing.T) {
 
 	web.validateAndSetDefaults()
 
-	if web.CtxRoot() != expected {
-		t.Errorf("expected %s, got %s", expected, web.CtxRoot())
-	}
+	t.Fatal("Should've panicked because the configuration specifies an invalid context root")
 }
 
 func TestWebConfig_ContextRootMultiPath(t *testing.T) {
-	const expected = "/app/status"
+	const expected = "/app/status/"
 	web := &webConfig{
 		ContextRoot: "/app/status",
 	}
 
 	web.validateAndSetDefaults()
 
-	if web.CtxRoot() != expected {
-		t.Errorf("expected %s, got %s", expected, web.CtxRoot())
+	if web.ContextRoot != expected {
+		t.Errorf("expected %s, got %s", expected, web.ContextRoot)
 	}
 }
 
@@ -59,8 +71,8 @@ func TestWebConfig_ContextRootAppendWithEmptyContextRoot(t *testing.T) {
 
 	web.validateAndSetDefaults()
 
-	if web.AppendToCtxRoot("/bla/") != expected {
-		t.Errorf("expected %s, got %s", expected, web.AppendToCtxRoot("/bla/"))
+	if web.AppendToContexRoot("/bla/") != expected {
+		t.Errorf("expected %s, got %s", expected, web.AppendToContexRoot("/bla/"))
 	}
 }
 
@@ -72,7 +84,7 @@ func TestWebConfig_ContextRootAppendWithContext(t *testing.T) {
 
 	web.validateAndSetDefaults()
 
-	if web.AppendToCtxRoot("/bla/") != expected {
-		t.Errorf("expected %s, got %s", expected, web.AppendToCtxRoot("/bla/"))
+	if web.AppendToContexRoot("/bla/") != expected {
+		t.Errorf("expected %s, got %s", expected, web.AppendToContexRoot("/bla/"))
 	}
 }

--- a/config/web_test.go
+++ b/config/web_test.go
@@ -31,6 +31,8 @@ var validContextRootTests = []struct {
 	{"Multiple slashes at start", "//status", "/status/"},
 	{"Mutliple slashes at start and end", "///status////", "/status/"},
 	{"Contains '@' in path'", "me@/status/gatus", "/me@/status/gatus/"},
+	{"nested context with trailing slash", "/status/gatus/", "/status/gatus/"},
+	{"nested context without trailing slash", "/status/gatus/system", "/status/gatus/system/"},
 }
 
 func TestWebConfig_ValidContextRoots(t *testing.T) {
@@ -42,7 +44,7 @@ func TestWebConfig_ValidContextRoots(t *testing.T) {
 }
 
 // invalidContextRootTests contains all tests for context root which are
-// expected to
+// expected to fail and stop program execution
 var invalidContextRootTests = []struct {
 	name string
 	path string

--- a/config/web_test.go
+++ b/config/web_test.go
@@ -11,3 +11,68 @@ func TestWebConfig_SocketAddress(t *testing.T) {
 		t.Errorf("expected %s, got %s", "0.0.0.0:8081", web.SocketAddress())
 	}
 }
+
+func TestWebConfig_ContextRoot(t *testing.T) {
+	const expected = "/status/"
+
+	web := &webConfig{
+		ContextRoot: "/status/",
+	}
+
+	web.validateAndSetDefaults()
+
+	if web.CtxRoot() != expected {
+		t.Errorf("expected %s, got %s", expected, web.CtxRoot())
+	}
+}
+
+func TestWebConfig_ContextRootWithEscapableChars(t *testing.T) {
+	const expected = "/s%3F=ta%20t%20u&s/"
+
+	web := &webConfig{
+		ContextRoot: "/s?=ta t u&s/",
+	}
+
+	web.validateAndSetDefaults()
+
+	if web.CtxRoot() != expected {
+		t.Errorf("expected %s, got %s", expected, web.CtxRoot())
+	}
+}
+
+func TestWebConfig_ContextRootMultiPath(t *testing.T) {
+	const expected = "/app/status"
+	web := &webConfig{
+		ContextRoot: "/app/status",
+	}
+
+	web.validateAndSetDefaults()
+
+	if web.CtxRoot() != expected {
+		t.Errorf("expected %s, got %s", expected, web.CtxRoot())
+	}
+}
+
+func TestWebConfig_ContextRootAppendWithEmptyContextRoot(t *testing.T) {
+	const expected = "/bla/"
+	web := &webConfig{}
+
+	web.validateAndSetDefaults()
+
+	if web.AppendToCtxRoot("/bla/") != expected {
+		t.Errorf("expected %s, got %s", expected, web.AppendToCtxRoot("/bla/"))
+	}
+}
+
+func TestWebConfig_ContextRootAppendWithContext(t *testing.T) {
+	const expected = "/app/status/bla/"
+	web := &webConfig{
+		ContextRoot: "/app/status",
+	}
+
+	web.validateAndSetDefaults()
+
+	if web.AppendToCtxRoot("/bla/") != expected {
+		t.Errorf("expected %s, got %s", expected, web.AppendToCtxRoot("/bla/"))
+	}
+}

--- a/main.go
+++ b/main.go
@@ -31,14 +31,14 @@ func main() {
 	}
 	// favicon needs to be always served from the root
 	http.HandleFunc("/favicon.ico", favIconHandler)
-	http.HandleFunc(cfg.Web.AppendToCtxRoot("/api/v1/results"), resultsHandler)
-	http.HandleFunc(cfg.Web.AppendToCtxRoot("/health"), healthHandler)
-	http.Handle(cfg.Web.CtxRoot(), GzipHandler(http.StripPrefix(cfg.Web.CtxRoot(), http.FileServer(http.Dir("./static")))))
+	http.HandleFunc(cfg.Web.AppendToContexRoot("/api/v1/results"), resultsHandler)
+	http.HandleFunc(cfg.Web.AppendToContexRoot("/health"), healthHandler)
+	http.Handle(cfg.Web.ContextRoot, GzipHandler(http.StripPrefix(cfg.Web.ContextRoot, http.FileServer(http.Dir("./static")))))
 
 	if cfg.Metrics {
-		http.Handle(cfg.Web.AppendToCtxRoot("/metrics"), promhttp.Handler())
+		http.Handle(cfg.Web.AppendToContexRoot("/metrics"), promhttp.Handler())
 	}
-	log.Printf("[main][main] Listening on %s%s\n", cfg.Web.SocketAddress(), cfg.Web.CtxRoot())
+	log.Printf("[main][main] Listening on %s%s\n", cfg.Web.SocketAddress(), cfg.Web.ContextRoot)
 	go watchdog.Monitor(cfg)
 	log.Fatal(http.ListenAndServe(cfg.Web.SocketAddress(), nil))
 }

--- a/main.go
+++ b/main.go
@@ -29,13 +29,16 @@ func main() {
 	if cfg.Security != nil && cfg.Security.IsValid() {
 		resultsHandler = security.Handler(serviceResultsHandler, cfg.Security)
 	}
-	http.HandleFunc("/api/v1/results", resultsHandler)
-	http.HandleFunc("/health", healthHandler)
-	http.Handle("/", GzipHandler(http.FileServer(http.Dir("./static"))))
+	// favicon needs to be always served from the root
+	http.HandleFunc("/favicon.ico", favIconHandler)
+	http.HandleFunc(cfg.Web.AppendToCtxRoot("/api/v1/results"), resultsHandler)
+	http.HandleFunc(cfg.Web.AppendToCtxRoot("/health"), healthHandler)
+	http.Handle(cfg.Web.CtxRoot(), GzipHandler(http.StripPrefix(cfg.Web.CtxRoot(), http.FileServer(http.Dir("./static")))))
+
 	if cfg.Metrics {
-		http.Handle("/metrics", promhttp.Handler())
+		http.Handle(cfg.Web.AppendToCtxRoot("/metrics"), promhttp.Handler())
 	}
-	log.Printf("[main][main] Listening on %s\n", cfg.Web.SocketAddress())
+	log.Printf("[main][main] Listening on %s%s\n", cfg.Web.SocketAddress(), cfg.Web.CtxRoot())
 	go watchdog.Monitor(cfg)
 	log.Fatal(http.ListenAndServe(cfg.Web.SocketAddress(), nil))
 }
@@ -87,4 +90,9 @@ func healthHandler(writer http.ResponseWriter, _ *http.Request) {
 	writer.Header().Add("Content-type", "application/json")
 	writer.WriteHeader(http.StatusOK)
 	_, _ = writer.Write([]byte("{\"status\":\"UP\"}"))
+}
+
+// favIconHanlder responds to /favicon.ico requests
+func favIconHandler(writer http.ResponseWriter, request *http.Request) {
+	http.ServeFile(writer, request, "./static/favicon.ico")
 }

--- a/main.go
+++ b/main.go
@@ -31,12 +31,12 @@ func main() {
 	}
 	// favicon needs to be always served from the root
 	http.HandleFunc("/favicon.ico", favIconHandler)
-	http.HandleFunc(cfg.Web.AppendToContexRoot("/api/v1/results"), resultsHandler)
-	http.HandleFunc(cfg.Web.AppendToContexRoot("/health"), healthHandler)
+	http.HandleFunc(cfg.Web.PrependWithContextRoot("/api/v1/results"), resultsHandler)
+	http.HandleFunc(cfg.Web.PrependWithContextRoot("/health"), healthHandler)
 	http.Handle(cfg.Web.ContextRoot, GzipHandler(http.StripPrefix(cfg.Web.ContextRoot, http.FileServer(http.Dir("./static")))))
 
 	if cfg.Metrics {
-		http.Handle(cfg.Web.AppendToContexRoot("/metrics"), promhttp.Handler())
+		http.Handle(cfg.Web.PrependWithContextRoot("/metrics"), promhttp.Handler())
 	}
 	log.Printf("[main][main] Listening on %s%s\n", cfg.Web.SocketAddress(), cfg.Web.ContextRoot)
 	go watchdog.Monitor(cfg)

--- a/static/index.html
+++ b/static/index.html
@@ -3,7 +3,7 @@
 <head>
 	<title>Health Dashboard</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<link rel="stylesheet" href="/bootstrap.min.css" />
+	<link rel="stylesheet" href="./bootstrap.min.css" />
 	<style>
 		html, body {
 			background-color: #f7f9fb;
@@ -129,11 +129,11 @@
 		</div>
 	</div>
 
-	<script src="/jquery.min.js"></script>
+	<script src="./jquery.min.js"></script>
 
 	<div id="social">
 		<a href="https://github.com/TwinProduction/gatus" target="_blank" title="Gatus on GitHub">
-			<img src="/github.png" alt="GitHub" width="32" height="auto" />
+			<img src="./github.png" alt="GitHub" width="32" height="auto" />
 		</a>
 	</div>
 
@@ -220,7 +220,7 @@
 		}
 
 		function refreshResults() {
-			$.getJSON("/api/v1/results", function (data) {
+			$.getJSON("./api/v1/results", function (data) {
 				// Update the table only if there's a change
 				if (JSON.stringify(serviceStatuses) !== JSON.stringify(data)) {
 					serviceStatuses = data;


### PR DESCRIPTION
This pull request adds the opportunity to configure the context root of the web application. Therefore it extends the web configuration object as suggested in #45 and performs some checks to validate the given context. The basic idea of the validation approach is to utilize Go's URL parser to create a URL from the supplied path and check for equality afterward.

Addresses #45 