### PR TITLE
Split memory map out of watchdog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin
 .idea
 .vscode
+gatus

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -79,7 +79,7 @@ func serviceStatusesHandler(writer http.ResponseWriter, r *http.Request) {
 		var err error
 		buffer := &bytes.Buffer{}
 		gzipWriter := gzip.NewWriter(buffer)
-		data, err = watchdog.GetJSONEncodedServiceStatuses()
+		data, err = watchdog.GetServiceStatusesAsJSON()
 		if err != nil {
 			log.Printf("[main][serviceStatusesHandler] Unable to marshal object to JSON: %s", err.Error())
 			writer.WriteHeader(http.StatusInternalServerError)

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -43,11 +43,8 @@ func (ims *InMemoryStore) GetAll() map[string]*core.ServiceStatus {
 func (ims *InMemoryStore) GetServiceStatus(group, name string) *core.ServiceStatus {
 	key := fmt.Sprintf("%s_%s", group, name)
 	ims.serviceResultsMutex.RLock()
-	serviceStatus, exists := ims.serviceStatuses[key]
+	serviceStatus := ims.serviceStatuses[key]
 	ims.serviceResultsMutex.RUnlock()
-	if !exists {
-		return nil
-	}
 	return serviceStatus
 }
 

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -24,7 +24,7 @@ func NewInMemoryStore() *InMemoryStore {
 
 // GetAll returns all the observed results for all services from the in memory store
 func (ims *InMemoryStore) GetAll() map[string]*core.ServiceStatus {
-	results := make(map[string]*core.ServiceStatus)
+	results := make(map[string]*core.ServiceStatus, len(ims.serviceStatuses))
 	ims.serviceResultsMutex.RLock()
 	for key, svcStatus := range ims.serviceStatuses {
 		copiedResults := copyResults(svcStatus.Results)

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -97,3 +97,10 @@ func copyErrors(errors []string) []string {
 	}
 	return copiedErrors
 }
+
+// Clear will empty all the results from the in memory store
+func (ims *InMemoryStore) Clear() {
+	serviceResultsMutex.Lock()
+	serviceStatuses = make(map[string]*core.ServiceStatus)
+	serviceResultsMutex.Unlock()
+}

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -1,0 +1,99 @@
+package storage
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/TwinProduction/gatus/core"
+)
+
+var (
+	serviceStatuses = make(map[string]*core.ServiceStatus)
+
+	// serviceResultsMutex is used to prevent concurrent map access
+	serviceResultsMutex sync.RWMutex
+)
+
+// InMemoryStore implements an in-memory store
+type InMemoryStore struct{}
+
+// NewInMemoryStore returns an in-memory store. Note that the store acts as a singleton, so although new-ing
+// up in-memory stores will give you a unique reference to a struct each time, all structs returned
+// by this function will act on the same in-memory store.
+func NewInMemoryStore() InMemoryStore {
+	return InMemoryStore{}
+}
+
+// GetAll returns all the observed results for all services from the in memory store
+func (ims *InMemoryStore) GetAll() map[string]*core.ServiceStatus {
+	results := make(map[string]*core.ServiceStatus)
+	serviceResultsMutex.RLock()
+	for key, svcStatus := range serviceStatuses {
+		copiedResults := copyResults(svcStatus.Results)
+		results[key] = &core.ServiceStatus{
+			Name:    svcStatus.Name,
+			Group:   svcStatus.Group,
+			Results: copiedResults,
+		}
+	}
+	serviceResultsMutex.RUnlock()
+
+	return results
+}
+
+// Insert inserts the observed result for the specified service into the in memory store
+func (ims *InMemoryStore) Insert(service *core.Service, result *core.Result) {
+	key := fmt.Sprintf("%s_%s", service.Group, service.Name)
+	serviceResultsMutex.Lock()
+	serviceStatus, exists := serviceStatuses[key]
+	if !exists {
+		serviceStatus = core.NewServiceStatus(service)
+		serviceStatuses[key] = serviceStatus
+	}
+	serviceStatus.AddResult(result)
+	serviceResultsMutex.Unlock()
+}
+
+func copyResults(results []*core.Result) []*core.Result {
+	copiedResults := []*core.Result{}
+	for _, result := range results {
+		copiedErrors := copyErrors(result.Errors)
+		copiedConditionResults := copyConditionResults(result.ConditionResults)
+
+		copiedResults = append(copiedResults, &core.Result{
+			HTTPStatus:            result.HTTPStatus,
+			DNSRCode:              result.DNSRCode,
+			Body:                  result.Body,
+			Hostname:              result.Hostname,
+			IP:                    result.IP,
+			Connected:             result.Connected,
+			Duration:              result.Duration,
+			Errors:                copiedErrors,
+			ConditionResults:      copiedConditionResults,
+			Success:               result.Connected,
+			Timestamp:             result.Timestamp,
+			CertificateExpiration: result.CertificateExpiration,
+		})
+	}
+	return copiedResults
+}
+
+func copyConditionResults(crs []*core.ConditionResult) []*core.ConditionResult {
+	copiedConditionResults := []*core.ConditionResult{}
+	for _, conditionResult := range crs {
+		copiedConditionResults = append(copiedConditionResults, &core.ConditionResult{
+			Condition: conditionResult.Condition,
+			Success:   conditionResult.Success,
+		})
+	}
+
+	return copiedConditionResults
+}
+
+func copyErrors(errors []string) []string {
+	copiedErrors := []string{}
+	for _, error := range errors {
+		copiedErrors = append(copiedErrors, error)
+	}
+	return copiedErrors
+}

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -16,8 +16,8 @@ type InMemoryStore struct {
 // NewInMemoryStore returns an in-memory store. Note that the store acts as a singleton, so although new-ing
 // up in-memory stores will give you a unique reference to a struct each time, all structs returned
 // by this function will act on the same in-memory store.
-func NewInMemoryStore() InMemoryStore {
-	return InMemoryStore{
+func NewInMemoryStore() *InMemoryStore {
+	return &InMemoryStore{
 		serviceStatuses: make(map[string]*core.ServiceStatus),
 	}
 }

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -41,6 +41,18 @@ func (ims *InMemoryStore) GetAll() map[string]*core.ServiceStatus {
 	return results
 }
 
+// GetServiceStatus returns the service status for a given service name in the given group
+func (ims *InMemoryStore) GetServiceStatus(group, name string) *core.ServiceStatus {
+	key := fmt.Sprintf("%s_%s", group, name)
+	serviceResultsMutex.RLock()
+	serviceStatus, exists := serviceStatuses[key]
+	serviceResultsMutex.RUnlock()
+	if !exists {
+		return nil
+	}
+	return serviceStatus
+}
+
 // Insert inserts the observed result for the specified service into the in memory store
 func (ims *InMemoryStore) Insert(service *core.Service, result *core.Result) {
 	key := fmt.Sprintf("%s_%s", service.Group, service.Name)

--- a/storage/memory_test.go
+++ b/storage/memory_test.go
@@ -1,0 +1,404 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/TwinProduction/gatus/core"
+)
+
+var testService = core.Service{
+	Name:                    "Name",
+	Group:                   "Group",
+	URL:                     "URL",
+	DNS:                     &core.DNS{QueryType: "QueryType", QueryName: "QueryName"},
+	Method:                  "Method",
+	Body:                    "Body",
+	GraphQL:                 false,
+	Headers:                 nil,
+	Interval:                time.Second * 2,
+	Conditions:              nil,
+	Alerts:                  nil,
+	Insecure:                false,
+	NumberOfFailuresInARow:  0,
+	NumberOfSuccessesInARow: 0,
+}
+
+var memoryStore = NewInMemoryStore()
+
+func TestStorage_GetAllFromEmptyMemoryStoreReturnsNothing(t *testing.T) {
+	memoryStore.Clear()
+	results := memoryStore.GetAll()
+	if len(results) != 0 {
+		t.Errorf("MemoryStore should've returned 0 results, but actually returned %d", len(results))
+	}
+}
+
+func TestStorage_InsertIntoEmptyMemoryStoreThenGetAllReturnsOneResult(t *testing.T) {
+	memoryStore.Clear()
+	result := core.Result{
+		HTTPStatus:            200,
+		DNSRCode:              "DNSRCode",
+		Body:                  nil,
+		Hostname:              "Hostname",
+		IP:                    "IP",
+		Connected:             false,
+		Duration:              time.Second * 2,
+		Errors:                nil,
+		ConditionResults:      nil,
+		Success:               false,
+		Timestamp:             time.Now(),
+		CertificateExpiration: time.Second * 2,
+	}
+
+	memoryStore.Insert(&testService, &result)
+
+	results := memoryStore.GetAll()
+	if len(results) != 1 {
+		t.Errorf("MemoryStore should've returned 0 results, but actually returned %d", len(results))
+	}
+
+	key := fmt.Sprintf("%s_%s", testService.Group, testService.Name)
+	storedResult, exists := results[key]
+	if !exists {
+		t.Fatalf("In Memory Store should've contained key '%s', but didn't", key)
+	}
+
+	if storedResult.Name != testService.Name {
+		t.Errorf("Stored Results Name should've been %s, but was %s", testService.Name, storedResult.Name)
+	}
+	if storedResult.Group != testService.Group {
+		t.Errorf("Stored Results Group should've been %s, but was %s", testService.Group, storedResult.Group)
+	}
+	if len(storedResult.Results) != 1 {
+		t.Errorf("Stored Results for service %s should've had 1 result, but actually had %d", storedResult.Name, len(storedResult.Results))
+	}
+	if storedResult.Results[0] == &result {
+		t.Errorf("Returned result is the same reference as result passed to insert. Returned result should be copies only")
+	}
+}
+
+func TestStorage_InsertTwoResultsForSingleServiceIntoEmptyMemoryStore_ThenGetAllReturnsTwoResults(t *testing.T) {
+	memoryStore.Clear()
+	result1 := core.Result{
+		HTTPStatus:            404,
+		DNSRCode:              "DNSRCode",
+		Body:                  nil,
+		Hostname:              "Hostname",
+		IP:                    "IP",
+		Connected:             false,
+		Duration:              time.Second * 2,
+		Errors:                nil,
+		ConditionResults:      nil,
+		Success:               false,
+		Timestamp:             time.Now(),
+		CertificateExpiration: time.Second * 2,
+	}
+	result2 := core.Result{
+		HTTPStatus:            200,
+		DNSRCode:              "DNSRCode",
+		Body:                  nil,
+		Hostname:              "Hostname",
+		IP:                    "IP",
+		Connected:             true,
+		Duration:              time.Second * 2,
+		Errors:                nil,
+		ConditionResults:      nil,
+		Success:               true,
+		Timestamp:             time.Now(),
+		CertificateExpiration: time.Second * 2,
+	}
+
+	resultsToInsert := []core.Result{result1, result2}
+
+	memoryStore.Insert(&testService, &result1)
+	memoryStore.Insert(&testService, &result2)
+
+	results := memoryStore.GetAll()
+	if len(results) != 1 {
+		t.Fatalf("MemoryStore should've returned 1 results, but actually returned %d", len(results))
+	}
+
+	key := fmt.Sprintf("%s_%s", testService.Group, testService.Name)
+	serviceResults, exists := results[key]
+	if !exists {
+		t.Fatalf("In Memory Store should've contained key '%s', but didn't", key)
+	}
+
+	if len(serviceResults.Results) != 2 {
+		t.Fatalf("Service '%s' should've had 2 results, but actually returned %d", serviceResults.Name, len(serviceResults.Results))
+	}
+
+	for i, r := range serviceResults.Results {
+		expectedResult := resultsToInsert[i]
+
+		if r.HTTPStatus != expectedResult.HTTPStatus {
+			t.Errorf("Result at index %d should've had a HTTPStatus of %d, but was actually %d", i, expectedResult.HTTPStatus, r.HTTPStatus)
+		}
+		if r.DNSRCode != expectedResult.DNSRCode {
+			t.Errorf("Result at index %d should've had a DNSRCode of %s, but was actually %s", i, expectedResult.DNSRCode, r.DNSRCode)
+		}
+		if len(r.Body) != len(expectedResult.Body) {
+			t.Errorf("Result at index %d should've had a body of length %d, but was actually %d", i, len(expectedResult.Body), len(r.Body))
+		}
+		if r.Hostname != expectedResult.Hostname {
+			t.Errorf("Result at index %d should've had a Hostname of %s, but was actually %s", i, expectedResult.Hostname, r.Hostname)
+		}
+		if r.IP != expectedResult.IP {
+			t.Errorf("Result at index %d should've had a IP of %s, but was actually %s", i, expectedResult.IP, r.IP)
+		}
+		if r.Connected != expectedResult.Connected {
+			t.Errorf("Result at index %d should've had a Connected value of %t, but was actually %t", i, expectedResult.Connected, r.Connected)
+		}
+		if r.Duration != expectedResult.Duration {
+			t.Errorf("Result at index %d should've had a Duration of %s, but was actually %s", i, expectedResult.Duration.String(), r.Duration.String())
+		}
+		if len(r.Errors) != len(expectedResult.Errors) {
+			t.Errorf("Result at index %d should've had %d errors, but actually had %d errors", i, len(expectedResult.Errors), len(r.Errors))
+		}
+		if len(r.ConditionResults) != len(expectedResult.ConditionResults) {
+			t.Errorf("Result at index %d should've had %d ConditionResults, but actually had %d ConditionResults", i, len(expectedResult.ConditionResults), len(r.ConditionResults))
+		}
+		if r.Success != expectedResult.Success {
+			t.Errorf("Result at index %d should've had a Success of %t, but was actually %t", i, expectedResult.Success, r.Success)
+		}
+		if r.Timestamp != expectedResult.Timestamp {
+			t.Errorf("Result at index %d should've had a Timestamp of %s, but was actually %s", i, expectedResult.Timestamp.String(), r.Timestamp.String())
+		}
+		if r.CertificateExpiration != expectedResult.CertificateExpiration {
+			t.Errorf("Result at index %d should've had a CertificateExpiration of %s, but was actually %s", i, expectedResult.CertificateExpiration.String(), r.CertificateExpiration.String())
+		}
+	}
+}
+
+func TestStorage_InsertTwoResultsTwoServicesIntoEmptyMemoryStore_ThenGetAllReturnsTwoServicesWithOneResultEach(t *testing.T) {
+	memoryStore.Clear()
+	result1 := core.Result{
+		HTTPStatus:            404,
+		DNSRCode:              "DNSRCode",
+		Body:                  nil,
+		Hostname:              "Hostname",
+		IP:                    "IP",
+		Connected:             false,
+		Duration:              time.Second * 2,
+		Errors:                nil,
+		ConditionResults:      nil,
+		Success:               false,
+		Timestamp:             time.Now(),
+		CertificateExpiration: time.Second * 2,
+	}
+	result2 := core.Result{
+		HTTPStatus:            200,
+		DNSRCode:              "DNSRCode",
+		Body:                  nil,
+		Hostname:              "Hostname",
+		IP:                    "IP",
+		Connected:             true,
+		Duration:              time.Second * 2,
+		Errors:                nil,
+		ConditionResults:      nil,
+		Success:               true,
+		Timestamp:             time.Now(),
+		CertificateExpiration: time.Second * 2,
+	}
+
+	testService2 := core.Service{
+		Name:                    "Name2",
+		Group:                   "Group",
+		URL:                     "URL",
+		DNS:                     &core.DNS{QueryType: "QueryType", QueryName: "QueryName"},
+		Method:                  "Method",
+		Body:                    "Body",
+		GraphQL:                 false,
+		Headers:                 nil,
+		Interval:                time.Second * 2,
+		Conditions:              nil,
+		Alerts:                  nil,
+		Insecure:                false,
+		NumberOfFailuresInARow:  0,
+		NumberOfSuccessesInARow: 0,
+	}
+
+	memoryStore.Insert(&testService, &result1)
+	memoryStore.Insert(&testService2, &result2)
+
+	results := memoryStore.GetAll()
+	if len(results) != 2 {
+		t.Fatalf("MemoryStore should've returned 2 results, but actually returned %d", len(results))
+	}
+
+	key := fmt.Sprintf("%s_%s", testService.Group, testService.Name)
+	serviceResults1, exists := results[key]
+	if !exists {
+		t.Fatalf("In Memory Store should've contained key '%s', but didn't", key)
+	}
+
+	if len(serviceResults1.Results) != 1 {
+		t.Fatalf("Service '%s' should've had 1 results, but actually returned %d", serviceResults1.Name, len(serviceResults1.Results))
+	}
+
+	key = fmt.Sprintf("%s_%s", testService2.Group, testService2.Name)
+	serviceResults2, exists := results[key]
+	if !exists {
+		t.Fatalf("In Memory Store should've contained key '%s', but didn't", key)
+	}
+
+	if len(serviceResults2.Results) != 1 {
+		t.Fatalf("Service '%s' should've had 1 results, but actually returned %d", serviceResults1.Name, len(serviceResults1.Results))
+	}
+}
+
+func TestStorage_InsertResultForServiceWithErrorsIntoEmptyMemoryStore_ThenGetAllReturnsOneResultWithErrors(t *testing.T) {
+	memoryStore.Clear()
+	errors := []string{
+		"error1",
+		"error2",
+	}
+	result1 := core.Result{
+		HTTPStatus:            404,
+		DNSRCode:              "DNSRCode",
+		Body:                  nil,
+		Hostname:              "Hostname",
+		IP:                    "IP",
+		Connected:             false,
+		Duration:              time.Second * 2,
+		Errors:                errors,
+		ConditionResults:      nil,
+		Success:               false,
+		Timestamp:             time.Now(),
+		CertificateExpiration: time.Second * 2,
+	}
+
+	memoryStore.Insert(&testService, &result1)
+
+	results := memoryStore.GetAll()
+	if len(results) != 1 {
+		t.Fatalf("MemoryStore should've returned 1 results, but actually returned %d", len(results))
+	}
+
+	key := fmt.Sprintf("%s_%s", testService.Group, testService.Name)
+	serviceResults, exists := results[key]
+	if !exists {
+		t.Fatalf("In Memory Store should've contained key '%s', but didn't", key)
+	}
+
+	if len(serviceResults.Results) != 1 {
+		t.Fatalf("Service '%s' should've had 2 results, but actually returned %d", serviceResults.Name, len(serviceResults.Results))
+	}
+
+	actualResult := serviceResults.Results[0]
+
+	if len(actualResult.Errors) != len(errors) {
+		t.Errorf("Service result should've had 2 errors, but actually had %d errors", len(actualResult.Errors))
+	}
+
+	for i, err := range actualResult.Errors {
+		if err != errors[i] {
+			t.Errorf("Error at index %d should've been %s, but was actually %s", i, errors[i], err)
+		}
+	}
+}
+
+func TestStorage_InsertResultForServiceWithConditionResultsIntoEmptyMemoryStore_ThenGetAllReturnsOneResultWithConditionResults(t *testing.T) {
+	memoryStore.Clear()
+	crs := []*core.ConditionResult{
+		{
+			Condition: "condition1",
+			Success:   true,
+		},
+		{
+			Condition: "condition2",
+			Success:   false,
+		},
+	}
+	result := core.Result{
+		HTTPStatus:            404,
+		DNSRCode:              "DNSRCode",
+		Body:                  nil,
+		Hostname:              "Hostname",
+		IP:                    "IP",
+		Connected:             false,
+		Duration:              time.Second * 2,
+		Errors:                nil,
+		ConditionResults:      crs,
+		Success:               false,
+		Timestamp:             time.Now(),
+		CertificateExpiration: time.Second * 2,
+	}
+
+	memoryStore.Insert(&testService, &result)
+
+	results := memoryStore.GetAll()
+	if len(results) != 1 {
+		t.Fatalf("MemoryStore should've returned 1 results, but actually returned %d", len(results))
+	}
+
+	key := fmt.Sprintf("%s_%s", testService.Group, testService.Name)
+	serviceResults, exists := results[key]
+	if !exists {
+		t.Fatalf("In Memory Store should've contained key '%s', but didn't", key)
+	}
+
+	if len(serviceResults.Results) != 1 {
+		t.Fatalf("Service '%s' should've had 2 results, but actually returned %d", serviceResults.Name, len(serviceResults.Results))
+	}
+
+	actualResult := serviceResults.Results[0]
+
+	if len(actualResult.ConditionResults) != len(crs) {
+		t.Errorf("Service result should've had 2 ConditionResults, but actually had %d ConditionResults", len(actualResult.Errors))
+	}
+
+	for i, cr := range actualResult.ConditionResults {
+		if cr.Condition != crs[i].Condition {
+			t.Errorf("ConditionResult at index %d should've had condition %s, but was actually %s", i, crs[i].Condition, cr.Condition)
+		}
+		if cr.Success != crs[i].Success {
+			t.Errorf("ConditionResult at index %d should've had success value of %t, but was actually %t", i, crs[i].Success, cr.Success)
+		}
+	}
+}
+
+func TestStorage_MultipleMemoryStoreInstancesReferToSameMemoryMap(t *testing.T) {
+	memoryStore.Clear()
+	currentMap := memoryStore.GetAll()
+
+	otherMemoryStore := NewInMemoryStore()
+	otherMemoryStoresMap := otherMemoryStore.GetAll()
+
+	if len(currentMap) != len(otherMemoryStoresMap) {
+		t.Errorf("Multiple memory stores should refer to the same internal map, but 'memoryStore' returned %d results, and 'otherMemoryStore' returned %d results", len(currentMap), len(otherMemoryStoresMap))
+	}
+
+	memoryStore.Insert(&testService, &core.Result{})
+	currentMap = memoryStore.GetAll()
+	otherMemoryStoresMap = otherMemoryStore.GetAll()
+
+	if len(currentMap) != len(otherMemoryStoresMap) {
+		t.Errorf("Multiple memory stores should refer to the same internal map, but 'memoryStore' returned %d results after inserting, and 'otherMemoryStore' returned %d results after inserting", len(currentMap), len(otherMemoryStoresMap))
+	}
+
+	otherMemoryStore.Clear()
+	currentMap = memoryStore.GetAll()
+	otherMemoryStoresMap = otherMemoryStore.GetAll()
+
+	if len(currentMap) != len(otherMemoryStoresMap) {
+		t.Errorf("Multiple memory stores should refer to the same internal map, but 'memoryStore' returned %d results after clearing, and 'otherMemoryStore' returned %d results after clearing", len(currentMap), len(otherMemoryStoresMap))
+	}
+}
+
+func TestStorage_ModificationsToReturnedMapDoNotAffectInternalMap(t *testing.T) {
+	memoryStore.Clear()
+
+	memoryStore.Insert(&testService, &core.Result{})
+	modifiedResults := memoryStore.GetAll()
+	for k := range modifiedResults {
+		delete(modifiedResults, k)
+	}
+	results := memoryStore.GetAll()
+
+	if len(modifiedResults) == len(results) {
+		t.Errorf("Returned map from GetAll should be free to modify by the caller without affecting internal in-memory map, but length of results from in-memory map (%d) was equal to the length of results in modified map (%d)", len(results), len(modifiedResults))
+	}
+}

--- a/storage/memory_test.go
+++ b/storage/memory_test.go
@@ -402,3 +402,35 @@ func TestStorage_ModificationsToReturnedMapDoNotAffectInternalMap(t *testing.T) 
 		t.Errorf("Returned map from GetAll should be free to modify by the caller without affecting internal in-memory map, but length of results from in-memory map (%d) was equal to the length of results in modified map (%d)", len(results), len(modifiedResults))
 	}
 }
+
+func TestStorage_GetServiceStatusForExistingStatusReturnsThatServiceStatus(t *testing.T) {
+	memoryStore.Clear()
+
+	memoryStore.Insert(&testService, &core.Result{})
+	serviceStatus := memoryStore.GetServiceStatus(testService.Group, testService.Name)
+
+	if serviceStatus == nil {
+		t.Errorf("Returned service status for group '%s' and name '%s' was nil after inserting the service into the store", testService.Group, testService.Name)
+	}
+}
+
+func TestStorage_GetServiceStatusForMissingStatusReturnsNil(t *testing.T) {
+	memoryStore.Clear()
+
+	memoryStore.Insert(&testService, &core.Result{})
+
+	serviceStatus := memoryStore.GetServiceStatus("nonexistantgroup", "nonexistantname")
+	if serviceStatus != nil {
+		t.Errorf("Returned service status for group '%s' and name '%s' not nil after inserting the service into the store", testService.Group, testService.Name)
+	}
+
+	serviceStatus = memoryStore.GetServiceStatus(testService.Group, "nonexistantname")
+	if serviceStatus != nil {
+		t.Errorf("Returned service status for group '%s' and name '%s' not nil after inserting the service into the store", testService.Group, "nonexistantname")
+	}
+
+	serviceStatus = memoryStore.GetServiceStatus("nonexistantgroup", testService.Name)
+	if serviceStatus != nil {
+		t.Errorf("Returned service status for group '%s' and name '%s' not nil after inserting the service into the store", "nonexistantgroup", testService.Name)
+	}
+}

--- a/storage/memory_test.go
+++ b/storage/memory_test.go
@@ -360,7 +360,7 @@ func TestStorage_InsertResultForServiceWithConditionResultsIntoEmptyMemoryStore_
 	}
 }
 
-func TestStorage_MultipleMemoryStoreInstancesReferToSameMemoryMap(t *testing.T) {
+func TestStorage_MultipleMemoryStoreInstancesReferToDifferentInternalMaps(t *testing.T) {
 	memoryStore.Clear()
 	currentMap := memoryStore.GetAll()
 
@@ -368,23 +368,23 @@ func TestStorage_MultipleMemoryStoreInstancesReferToSameMemoryMap(t *testing.T) 
 	otherMemoryStoresMap := otherMemoryStore.GetAll()
 
 	if len(currentMap) != len(otherMemoryStoresMap) {
-		t.Errorf("Multiple memory stores should refer to the same internal map, but 'memoryStore' returned %d results, and 'otherMemoryStore' returned %d results", len(currentMap), len(otherMemoryStoresMap))
+		t.Errorf("Multiple memory stores should refer to the different internal maps, but 'memoryStore' returned %d results, and 'otherMemoryStore' returned %d results", len(currentMap), len(otherMemoryStoresMap))
 	}
 
 	memoryStore.Insert(&testService, &core.Result{})
 	currentMap = memoryStore.GetAll()
 	otherMemoryStoresMap = otherMemoryStore.GetAll()
 
-	if len(currentMap) != len(otherMemoryStoresMap) {
-		t.Errorf("Multiple memory stores should refer to the same internal map, but 'memoryStore' returned %d results after inserting, and 'otherMemoryStore' returned %d results after inserting", len(currentMap), len(otherMemoryStoresMap))
+	if len(currentMap) == len(otherMemoryStoresMap) {
+		t.Errorf("Multiple memory stores should refer to different internal maps, but 'memoryStore' returned %d results after inserting, and 'otherMemoryStore' returned %d results after inserting", len(currentMap), len(otherMemoryStoresMap))
 	}
 
 	otherMemoryStore.Clear()
 	currentMap = memoryStore.GetAll()
 	otherMemoryStoresMap = otherMemoryStore.GetAll()
 
-	if len(currentMap) != len(otherMemoryStoresMap) {
-		t.Errorf("Multiple memory stores should refer to the same internal map, but 'memoryStore' returned %d results after clearing, and 'otherMemoryStore' returned %d results after clearing", len(currentMap), len(otherMemoryStoresMap))
+	if len(currentMap) == len(otherMemoryStoresMap) {
+		t.Errorf("Multiple memory stores should refer to different internal maps, but 'memoryStore' returned %d results after clearing, and 'otherMemoryStore' returned %d results after clearing", len(currentMap), len(otherMemoryStoresMap))
 	}
 }
 

--- a/watchdog/watchdog.go
+++ b/watchdog/watchdog.go
@@ -21,8 +21,8 @@ var (
 	monitoringMutex sync.Mutex
 )
 
-// GetJSONEncodedServiceStatuses returns a list of core.ServiceStatus for each services encoded using json.Marshal.
-func GetJSONEncodedServiceStatuses() ([]byte, error) {
+// GetServiceStatusesAsJSON returns a list of core.ServiceStatus for each services encoded using json.Marshal.
+func GetServiceStatusesAsJSON() ([]byte, error) {
 	serviceStatuses := store.GetAll()
 	data, err := json.Marshal(serviceStatuses)
 	return data, err

--- a/watchdog/watchdog.go
+++ b/watchdog/watchdog.go
@@ -22,7 +22,6 @@ var (
 )
 
 // GetJSONEncodedServiceStatuses returns a list of core.ServiceStatus for each services encoded using json.Marshal.
-// The reason why the encoding is done here is because we use a mutex to prevent concurrent map access.
 func GetJSONEncodedServiceStatuses() ([]byte, error) {
 	serviceStatuses := store.GetAll()
 	data, err := json.Marshal(serviceStatuses)

--- a/watchdog/watchdog.go
+++ b/watchdog/watchdog.go
@@ -30,10 +30,8 @@ func GetServiceStatusesAsJSON() ([]byte, error) {
 
 // GetUptimeByServiceGroupAndName returns the uptime of a service based on its group and name
 func GetUptimeByServiceGroupAndName(group, name string) *core.Uptime {
-	key := fmt.Sprintf("%s_%s", group, name)
-	serviceStatuses := store.GetAll()
-	serviceStatus, exists := serviceStatuses[key]
-	if !exists {
+	serviceStatus := store.GetServiceStatus(group, name)
+	if serviceStatus == nil {
 		return nil
 	}
 	return serviceStatus.Uptime

--- a/watchdog/watchdog.go
+++ b/watchdog/watchdog.go
@@ -24,8 +24,7 @@ var (
 // GetServiceStatusesAsJSON returns a list of core.ServiceStatus for each services encoded using json.Marshal.
 func GetServiceStatusesAsJSON() ([]byte, error) {
 	serviceStatuses := store.GetAll()
-	data, err := json.Marshal(serviceStatuses)
-	return data, err
+	return json.Marshal(serviceStatuses)
 }
 
 // GetUptimeByServiceGroupAndName returns the uptime of a service based on its group and name


### PR DESCRIPTION
The watchdog was responsible for a few things, notably handling the storage of evaluated service health results.

This doesn't _really_ feel like the watchdog's responsibility. Abstracting this behind a storage package feels more suitable, and isolates the storage logic in a single place, also making it testable.

This PR does the above - extracting the in memory store into its own storage package and making the watchdog consume that. This simplifies the code within the watchdog, and also introduces tests for the in memory store. This should also make it easier to extend the storage mechanism without changing the watchdog significantly (for example, adding support for persistent storage as in #32)

After running Gatus with 11 configured services, each evaluating health every 1s for 5 minutes, `pprof` showed no discernible detrimental impact on memory usage/garbage collection time:

<details>
<summary>pprof</summary>

Current master:

```
# runtime.MemStats
# Alloc = 3051472
# TotalAlloc = 190433512
# Sys = 73482496
# Lookups = 0
# Mallocs = 446717
# Frees = 423883
# HeapAlloc = 3051472
# HeapSys = 66420736
# HeapIdle = 61751296
# HeapInuse = 4669440
# HeapReleased = 60866560
# HeapObjects = 22834
# Stack = 688128 / 688128
# MSpan = 102816 / 131072
# MCache = 6944 / 16384
# BuckHashSys = 1454536
# GCSys = 3582216
# OtherSys = 1189424
# NextGC = 4775584
# LastGC = 1609418813213059000
# PauseNs = [120769 102056 34748 85775 353706 60758 125586 121698 31092 71211 57656 27131 56622 70200 68364 235575 38069 36683 104685 46811 54039 45072 34272 34439 89577 126771 68002 50735 93847 29398 32673 74851 336733 281438 57472 87634 42196 35606 73428 96430 810465 94151 71834 49864 84216 30230 43686 140493 101152 57180 38408 62516 31492 64476 57363 67384 282865 1664201 33948 31728 36371 53763 142659 68640 63699 149714 68264 66292 142875 62182 36437 123307 588000 56443 65739 44909 34380 110451 54026 29622 261328 32765 51138 151229 52313 98326 100363 99075 323726 111036 30781 92002 175413 42563 34227 29580 57132 46848 481856 288735 108125 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
# PauseEnd = [1609418499666967000 1609418503307155000 1609418507981938000 1609418512001531000 1609418516202892000 1609418519914843000 1609418523635964000 1609418527233094000 1609418530604905000 1609418532141963000 1609418535888694000 1609418539081773000 1609418542465630000 1609418545772688000 1609418548966882000 1609418552154820000 1609418555428029000 1609418558435214000 1609418561837927000 1609418562933073000 1609418565793482000 1609418569040246000 1609418572125297000 1609418575004436000 1609418578190456000 1609418581194303000 1609418584479262000 1609418587760271000 1609418591037082000 1609418592145238000 1609418596346675000 1609418599281217000 1609418602261983000 1609418605270865000 1609418608456392000 1609418611916627000 1609418615110489000 1609418618205202000 1609418621194030000 1609418622144854000 1609418626181100000 1609418629295337000 1609418632369099000 1609418635564342000 1609418638710268000 1609418641806279000 1609418644903498000 1609418648010668000 1609418652150233000 1609418653716675000 1609418656800644000 1609418659915917000 1609418662889920000 1609418665952467000 1609418668947608000 1609418671971956000 1609418675236778000 1609418678618678000 1609418681788150000 1609418682517390000 1609418685288716000 1609418688197622000 1609418689431597000 1609418692896627000 1609418696171286000 1609418699264014000 1609418702319614000 1609418705340281000 1609418708620899000 1609418712153678000 1609418716449991000 1609418719931592000 1609418723028359000 1609418726208306000 1609418729608272000 1609418732983740000 1609418736264600000 1609418739456901000 1609418742155302000 1609418746649921000 1609418750023130000 1609418753452617000 1609418756915068000 1609418760012618000 1609418763110505000 1609418766157818000 1609418769248356000 1609418772164743000 1609418777139150000 1609418780419138000 1609418783693433000 1609418786803594000 1609418789886187000 1609418793427487000 1609418796665774000 1609418799351919000 1609418802245566000 1609418803543071000 1609418806953853000 1609418810020784000 1609418813213059000 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
# NumGC = 101
# NumForcedGC = 0
# GCCPUFraction = 0.00020101637973740565
# DebugGC = false
```


This branch: 

```
# runtime.MemStats
# Alloc = 3472512
# TotalAlloc = 135699984
# Sys = 73482496
# Lookups = 0
# Mallocs = 356179
# Frees = 332522
# HeapAlloc = 3472512
# HeapSys = 66387968
# HeapIdle = 60948480
# HeapInuse = 5439488
# HeapReleased = 60776448
# HeapObjects = 23657
# Stack = 720896 / 720896
# MSpan = 103224 / 131072
# MCache = 6944 / 16384
# BuckHashSys = 1455562
# GCSys = 3582216
# OtherSys = 1188398
# NextGC = 4514864
# LastGC = 1609417860989698000
# PauseNs = [100019 29066 213562 981277 108664 36407 3909479 91835 88661 209753 126793 102633 104571 105571 100737 61661 192329 28517 161998 943051 34894 37663 31056 278971 38591 88562 59548 34418 1170616 48211 33382 37445 63221 180635 29893 30502 313117 56586 37705 46073 39124 200632 34004 200245 47554 38853 36112 173730 75400 133603 166733 37219 39917 1326155 64094 94380 110489 57322 42894 54963 39108 145373 29841 79738 11834837 69572 123239 264176 130389 27845 53447 3378785 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
# PauseEnd = [1609417640686181000 1609417645154150000 1609417647942864000 1609417650879378000 1609417653309042000 1609417656125549000 1609417658675512000 1609417661183432000 1609417662116233000 1609417665629426000 1609417668371075000 1609417671551539000 1609417674576022000 1609417677385121000 1609417679958957000 1609417682868200000 1609417685480117000 1609417688374566000 1609417691672385000 1609417692663055000 1609417697356308000 1609417700632536000 1609417704008603000 1609417707196615000 1609417710287442000 1609417713263792000 1609417716708196000 1609417719620651000 1609417722135812000 1609417727061259000 1609417730341068000 1609417733352557000 1609417736270677000 1609417739647685000 1609417743073261000 1609417746364654000 1609417749888347000 1609417752928662000 1609417753565045000 1609417756940873000 1609417760412858000 1609417763810445000 1609417766796562000 1609417769727790000 1609417772918795000 1609417775584749000 1609417778578101000 1609417781950035000 1609417782855878000 1609417786414021000 1609417789918705000 1609417793227514000 1609417796325301000 1609417799627483000 1609417802906537000 1609417806369298000 1609417809856801000 1609417812119948000 1609417816941977000 1609417820226856000 1609417823533533000 1609417826905248000 1609417830307338000 1609417833702906000 1609417837314921000 1609417839801390000 1609417842153722000 1609417847407490000 1609417850996370000 1609417854477157000 1609417857764484000 1609417860989698000 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
# NumGC = 72
# NumForcedGC = 0
# GCCPUFraction = 0.0003471378352739587
# DebugGC = false
```

</details>

Admittedly, my experience with `pprof` is very limited. So please let me know if you'd like me to perform further investigation into the performance impact of this change!