### PR TITLE
Make ALERT_TRIGGERED_OR_RESOLVED placeholder values configurable

### DIFF
--- a/alerting/provider/custom/custom_test.go
+++ b/alerting/provider/custom/custom_test.go
@@ -94,7 +94,7 @@ func TestAlertProvider_buildHTTPRequestWithCustomPlaceholder(t *testing.T) {
 	}
 }
 
-func TestAlertProvider_GetPlaceholderValue(t *testing.T) {
+func TestAlertProvider_GetAlertStatePlaceholderValueDefaults(t *testing.T) {
 	customAlertProvider := &AlertProvider{
 		URL:          "http://example.com/[SERVICE_NAME]?event=[ALERT_TRIGGERED_OR_RESOLVED]&description=[ALERT_DESCRIPTION]",
 		Body:         "[SERVICE_NAME],[ALERT_DESCRIPTION],[ALERT_TRIGGERED_OR_RESOLVED]",
@@ -102,15 +102,11 @@ func TestAlertProvider_GetPlaceholderValue(t *testing.T) {
 		Placeholders: nil,
 	}
 
-	if customAlertProvider.GetPlaceholderValue("I_DO_NOT_EXIST", "i_do_also_no_exist") != "" {
-		t.Error("expected empty response from a non existing placeholder")
+	if customAlertProvider.GetAlertStatePlaceholderValue(true) != "RESOLVED" {
+		t.Error("expected here actually RESOLVED")
 	}
 
-	if customAlertProvider.GetPlaceholderValue("ALERT_TRIGGERED_OR_RESOLVED", "I_DO_NOT_EXIST") != "" {
-		t.Error("expected empty response from a non existing subvalue")
-	}
-
-	if customAlertProvider.GetPlaceholderValue("ALERT_TRIGGERED_OR_RESOLVED", "triggered") != "TRIGGERED" {
-		t.Error("expected 'triggered' as a result")
+	if customAlertProvider.GetAlertStatePlaceholderValue(false) != "TRIGGERED" {
+		t.Error("expected here actually TRIGGERED")
 	}
 }

--- a/alerting/provider/custom/custom_test.go
+++ b/alerting/provider/custom/custom_test.go
@@ -68,3 +68,28 @@ func TestAlertProvider_ToCustomAlertProvider(t *testing.T) {
 		t.Error("customAlertProvider should've been equal to customAlertProvider")
 	}
 }
+
+func TestAlertProvider_buildHTTPRequestWithCustomPlaceholder(t *testing.T) {
+	const (
+		ExpectedURL  = "http://example.com/service-name?event=MYTEST&description=alert-description"
+		ExpectedBody = "service-name,alert-description,MYTEST"
+	)
+	customAlertProvider := &AlertProvider{
+		URL:     "http://example.com/[SERVICE_NAME]?event=[ALERT_TRIGGERED_OR_RESOLVED]&description=[ALERT_DESCRIPTION]",
+		Body:    "[SERVICE_NAME],[ALERT_DESCRIPTION],[ALERT_TRIGGERED_OR_RESOLVED]",
+		Headers: nil,
+		Placeholders: map[string]map[string]string{
+			"ALERT_TRIGGERED_OR_RESOLVED": {
+				"resolved": "MYTEST",
+			},
+		},
+	}
+	request := customAlertProvider.buildHTTPRequest("service-name", "alert-description", true)
+	if request.URL.String() != ExpectedURL {
+		t.Error("expected URL to be", ExpectedURL, "was", request.URL.String())
+	}
+	body, _ := ioutil.ReadAll(request.Body)
+	if string(body) != ExpectedBody {
+		t.Error("expected body to be", ExpectedBody, "was", string(body))
+	}
+}

--- a/alerting/provider/custom/custom_test.go
+++ b/alerting/provider/custom/custom_test.go
@@ -93,3 +93,24 @@ func TestAlertProvider_buildHTTPRequestWithCustomPlaceholder(t *testing.T) {
 		t.Error("expected body to be", ExpectedBody, "was", string(body))
 	}
 }
+
+func TestAlertProvider_GetPlaceholderValue(t *testing.T) {
+	customAlertProvider := &AlertProvider{
+		URL:          "http://example.com/[SERVICE_NAME]?event=[ALERT_TRIGGERED_OR_RESOLVED]&description=[ALERT_DESCRIPTION]",
+		Body:         "[SERVICE_NAME],[ALERT_DESCRIPTION],[ALERT_TRIGGERED_OR_RESOLVED]",
+		Headers:      nil,
+		Placeholders: nil,
+	}
+
+	if customAlertProvider.GetPlaceholderValue("I_DO_NOT_EXIST", "i_do_also_no_exist") != "" {
+		t.Error("expected empty response from a non existing placeholder")
+	}
+
+	if customAlertProvider.GetPlaceholderValue("ALERT_TRIGGERED_OR_RESOLVED", "I_DO_NOT_EXIST") != "" {
+		t.Error("expected empty response from a non existing subvalue")
+	}
+
+	if customAlertProvider.GetPlaceholderValue("ALERT_TRIGGERED_OR_RESOLVED", "triggered") != "TRIGGERED" {
+		t.Error("expected 'triggered' as a result")
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -344,6 +344,10 @@ alerting:
     access-key: "1"
     originator: "31619191918"
     recipients: "31619191919"
+  placeholders:
+    ALERT_TRIGGERED_OR_RESOLVED:
+      triggered: "partial_outage"
+      resolved: "operational"
 services:
   - name: twinnation
     url: https://twinnation.org/health

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -344,10 +344,11 @@ alerting:
     access-key: "1"
     originator: "31619191918"
     recipients: "31619191919"
-  placeholders:
-    ALERT_TRIGGERED_OR_RESOLVED:
-      triggered: "partial_outage"
-      resolved: "operational"
+  custom:
+    placeholders:
+      ALERT_TRIGGERED_OR_RESOLVED:
+        triggered: "partial_outage"
+        resolved: "operational"
 services:
   - name: twinnation
     url: https://twinnation.org/health
@@ -399,6 +400,12 @@ services:
 	}
 	if config.Alerting.Messagebird.Recipients != "31619191919" {
 		t.Errorf("Messagebird to recipients should've been %s, but was %s", "31619191919", config.Alerting.Messagebird.Recipients)
+	}
+	if config.Alerting.Custom == nil {
+		t.Fatal("config.Alerting. Custom shouldn't have been nil")
+	}
+	if config.Alerting.Custom.Placeholders == nil {
+		t.Fatal("config.Alerting.Custom.Placeholders shouldn't have been nil")
 	}
 	if len(config.Services) != 1 {
 		t.Error("There should've been 1 service")


### PR DESCRIPTION
I am a colleague of GeorgFleig which opened issue #76. This pull request  actually implements this feature in the form it was proposed in https://github.com/TwinProduction/gatus/issues/76#issuecomment-765863720

Would be awesome if it get merged. Feedback welcome.