### PR TITLE
add basic authentication support to HTTP based services

### DIFF
--- a/core/service.go
+++ b/core/service.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"github.com/TwinProduction/gatus/security"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -65,6 +66,9 @@ type Service struct {
 
 	// Headers of the request
 	Headers map[string]string `yaml:"headers,omitempty"`
+
+	// Basic HTTP Authentication
+	Security *security.Config `yaml:"security"`
 
 	// Interval is the duration to wait between every status check
 	Interval time.Duration `yaml:"interval,omitempty"`
@@ -245,6 +249,12 @@ func (service *Service) buildHTTPRequest() *http.Request {
 		bodyBuffer = bytes.NewBuffer([]byte(service.Body))
 	}
 	request, _ := http.NewRequest(service.Method, service.URL, bodyBuffer)
+
+	// sets Basic Authentication Header to request if found in Service Configuration
+	if service.Security != nil {
+		request.SetBasicAuth(service.Security.Basic.Username, service.Security.Basic.Password)
+	}
+
 	for k, v := range service.Headers {
 		request.Header.Set(k, v)
 		if k == HostHeader {

--- a/core/service_test.go
+++ b/core/service_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"github.com/TwinProduction/gatus/security"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -188,6 +189,29 @@ func TestService_buildHTTPRequestWithHostHeader(t *testing.T) {
 	}
 	if request.Host != "example.com" {
 		t.Error("request.Host should've been example.com, but was", request.Host)
+	}
+}
+
+func TestService_buildHTTPRequestWithBasicAuthentication(t *testing.T) {
+	condition := Condition("[STATUS] == 200")
+	service := Service{
+		Name:       "twinnation-health",
+		URL:        "https://twinnation.org/health",
+		Method:     "POST",
+		Conditions: []*Condition{&condition},
+		Security: &security.Config{Basic: &security.BasicConfig{
+			Username: "testusername",
+			Password: "testpassword",
+		}},
+	}
+	service.ValidateAndSetDefaults()
+	request := service.buildHTTPRequest()
+	if request.Method != "POST" {
+		t.Error("request.Method should've been POST, but was", request.Method)
+	}
+	username, password, _ := request.BasicAuth()
+	if username != "testusername" || password != "testpassword" {
+		t.Error("Basic Authentication header should have return username: 'testusername' and password: 'testpassword, but was", username, password)
 	}
 }
 

--- a/security/security.go
+++ b/security/security.go
@@ -17,6 +17,9 @@ type BasicConfig struct {
 
 	// PasswordSha512Hash is the SHA512 hash of the password which will need to be used for a successful authentication
 	PasswordSha512Hash string `yaml:"password-sha512"`
+
+	// Clear Text Password
+	Password string `yaml:"password"`
 }
 
 // IsValid returns whether the basic security configuration is valid or not


### PR DESCRIPTION
I have HTTP Service endpoints which require Basic Authentication when connecting. This PR adds a convenient way to add Basic Authentication to HTTP based services when required.

```
services:
  - name: front-end
    group: core
    url: "https://twinnation.org/health"
    interval: 1m
    conditions:
      - "[STATUS] == 200"
      - "[BODY].status == UP"
      - "[RESPONSE_TIME] < 150"
    security:
      basic:
        username: "gatus-monitoring-user"
        password: "someP@sSw0rd"
```

Not sure if it fits your style properly.