### PR TITLE
Add [MODIFIED] condition.

### DIFF
--- a/core/condition.go
+++ b/core/condition.go
@@ -36,6 +36,11 @@ const (
 	// Values that could replace the placeholder: {}, {"data":{"name":"john"}}, ...
 	BodyPlaceholder = "[BODY]"
 
+	// ModifiedPlaceholder is a placeholder for the whether the ETag header changed since the previous request
+	//
+	// Values that could replace the placeholder: true, false
+	ModifiedPlaceholder = "[MODIFIED]"
+
 	// ConnectedPlaceholder is a placeholder for whether a connection was successfully established.
 	//
 	// Values that could replace the placeholder: true, false
@@ -142,6 +147,12 @@ func (c Condition) hasBodyPlaceholder() bool {
 	return strings.Contains(string(c), BodyPlaceholder)
 }
 
+// hasModifiedPlaceholder checks whether the condition has a ModifiedPlaceholder
+// Used for determining whether the response ETag header should be read or not
+func (c Condition) hasModifiedPlaceholder() bool {
+	return strings.Contains(string(c), ModifiedPlaceholder)
+}
+
 // isEqual compares two strings.
 //
 // Supports the pattern and the any functions.
@@ -217,6 +228,8 @@ func sanitizeAndResolve(elements []string, result *Result) ([]string, []string) 
 			element = result.DNSRCode
 		case ConnectedPlaceholder:
 			element = strconv.FormatBool(result.Connected)
+		case ModifiedPlaceholder:
+			element = strconv.FormatBool(result.etag != result.previousEtag)
 		case CertificateExpirationPlaceholder:
 			element = strconv.FormatInt(result.CertificateExpiration.Milliseconds(), 10)
 		default:

--- a/core/result.go
+++ b/core/result.go
@@ -45,4 +45,11 @@ type Result struct {
 	// This means that the call Service.EvaluateHealth both populates the body (if necessary)
 	// and sets it to nil after the evaluation has been completed.
 	body []byte
+
+	// etag is from the ETag header recieved in the response
+	etag string
+
+	// previousEtag is the ETag that was received in the last request to the service.
+	// Used to check whether it changed since the last request.
+	previousEtag string
 }

--- a/core/service.go
+++ b/core/service.go
@@ -223,7 +223,7 @@ func (service *Service) call(result *Result) {
 			// way of smuggling the required state into the condition evaluation
 			// that I could think of without substantial re-architecturing.
 			result.previousEtag = service.previousEtag
-			result.etag = response.Header.Get("Etag")
+			result.etag = response.Header.Get("ETag")
 			service.previousEtag = result.etag
 		}
 	}

--- a/core/service.go
+++ b/core/service.go
@@ -84,8 +84,8 @@ type Service struct {
 	// NumberOfSuccessesInARow is the number of successful evaluations in a row
 	NumberOfSuccessesInARow int
 
-	// PreviousETag is the ETag that was received in the last request to the service.
-	PreviousEtag string
+	// previousEtag is the ETag that was received in the last request to the service.
+	previousEtag string
 }
 
 // ValidateAndSetDefaults validates the service's configuration and sets the default value of fields that have one
@@ -222,9 +222,9 @@ func (service *Service) call(result *Result) {
 			// This is pretty sub-prime, but it's the most straightforward
 			// way of smuggling the required state into the condition evaluation
 			// that I could think of without substantial re-architecturing.
-			result.previousEtag = service.PreviousEtag
+			result.previousEtag = service.previousEtag
 			result.etag = response.Header.Get("Etag")
-			service.PreviousEtag = result.etag
+			service.previousEtag = result.etag
 		}
 	}
 }


### PR DESCRIPTION
This change adds a [MODIFIED] condition that can be used to check that the resource specified by the URL changed since last retrieval. It does this by comparing the ETag header in the HTTP response.

My use-case is a heartbeat status file that should be updated every minute if the service is functioning properly.

If this is a feature that the maintainers feel would be useful please let me know and I'll finish off this PR with readme updates and tests.

I am not particularly happy with the means I am using to pass the previous ETag value through to the conditional evaluation code, but I wasn't able to see a way forward that wouldn't require substantial re-architecturing.