### PR TITLE
Add group-specific integration key for PagerDuty

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,8 +416,6 @@ services:
 | `alerting.pagerduty`                     | Configuration for alerts of type `pagerduty`                                  | `{}`           |
 | `alerting.pagerduty.integration-key`     | PagerDuty Events API v2 integration key.                                      | `""`           |
 | `alerting.pagerduty.default-alert`       | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A       |
-| `alerting.pagerduty.integrations`        | Pagerduty integrations per team configurations                                |                |
-| `alerting.pagerduty.integrations`        | Pagerduty integrations per team configurations                                |   `[]`         |
 | `alerting.pagerduty.integrations`        | Pagerduty integrations per team configurations                                |   `[]`         |
 | `alerting.pagerduty.integrations[].integration-key` | Pagerduty integrationkey for a perticular team                     |   `""`         |
 | `alerting.pagerduty.integrations[].group`           | the group that the integration key belongs to                      |   `""`         |

--- a/README.md
+++ b/README.md
@@ -414,18 +414,32 @@ services:
 | Parameter                                | Description                                                                   | Default        |
 |:---------------------------------------- |:----------------------------------------------------------------------------- |:-------------- |
 | `alerting.pagerduty`                     | Configuration for alerts of type `pagerduty`                                  | `{}`           |
-| `alerting.pagerduty.integration-key`     | PagerDuty Events API v2 integration key.                                      | Required `""`  |
+| `alerting.pagerduty.integration-key`     | PagerDuty Events API v2 integration key.                                      | `""`           |
 | `alerting.pagerduty.default-alert`       | Default alert configuration. <br />See [Setting a default alert](#setting-a-default-alert) | N/A       |
+| `alerting.pagerduty.integrations`        | Pagerduty integrations per team configurations                                |                |
+| `alerting.pagerduty.integrations`        | Pagerduty integrations per team configurations                                |   `[]`         |
+| `alerting.pagerduty.integrations`        | Pagerduty integrations per team configurations                                |   `[]`         |
+| `alerting.pagerduty.integrations[].integration-key` | Pagerduty integrationkey for a perticular team                     |   `""`         |
+| `alerting.pagerduty.integrations[].group`           | the group that the integration key belongs to                      |   `""`         |
 
 It is highly recommended to set `services[].alerts[].send-on-resolved` to `true` for alerts
 of type `pagerduty`, because unlike other alerts, the operation resulting from setting said
 parameter to `true` will not create another incident, but mark the incident as resolved on
 PagerDuty instead.
 
+Behavior:
+- Team integration have priority over the general integration
+- If no team integration is provided it will defaults to the general pagerduty integration 
+- If no team integration and no general integration were provided it defaults to the first team integration provided
+
+
 ```yaml
 alerting:
   pagerduty: 
     integration-key: "********************************"
+    intergrations:
+     - integration-key: "********************************"
+       group: "core"
 
 services:
   - name: website
@@ -435,6 +449,20 @@ services:
       - "[STATUS] == 200"
       - "[BODY].status == UP"
       - "[RESPONSE_TIME] < 300"
+    alerts:
+      - type: pagerduty
+        enabled: true
+        failure-threshold: 3
+        success-threshold: 5
+        send-on-resolved: true
+        description: "healthcheck failed"
+  - name: back-end
+    group: core
+    url: "https://example.org/"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+      - "[CERTIFICATE_EXPIRATION] > 48h"
     alerts:
       - type: pagerduty
         enabled: true

--- a/alerting/provider/pagerduty/pagerduty.go
+++ b/alerting/provider/pagerduty/pagerduty.go
@@ -52,7 +52,10 @@ func (provider *AlertProvider) GetPagerDutyIntegrationKey(group string) string {
 			}
 		}
 	}
-	return provider.IntegrationKey
+	if provider.IntegrationKey != "" {
+		return provider.IntegrationKey
+	}
+	return provider.Integrations[0].IntegrationKey
 }
 
 // ToCustomAlertProvider converts the provider into a custom.AlertProvider

--- a/alerting/provider/pagerduty/pagerduty.go
+++ b/alerting/provider/pagerduty/pagerduty.go
@@ -43,19 +43,18 @@ func (provider *AlertProvider) IsValid() bool {
 }
 
 // GetPagerDutyIntegrationKey returns the appropriate pagerduty integration key
-
 func (provider *AlertProvider) GetPagerDutyIntegrationKey(group string) string {
 	if provider.Integrations != nil {
-		for _, itegration := range provider.Integrations {
-			if group == itegration.Group {
-				return itegration.IntegrationKey
+		for _, integration := range provider.Integrations {
+			if group == integration.Group {
+				return integration.IntegrationKey
 			}
 		}
 	}
 	if provider.IntegrationKey != "" {
 		return provider.IntegrationKey
 	}
-	return provider.Integrations[0].IntegrationKey
+	return ""
 }
 
 // ToCustomAlertProvider converts the provider into a custom.AlertProvider

--- a/alerting/provider/pagerduty/pagerduty.go
+++ b/alerting/provider/pagerduty/pagerduty.go
@@ -30,13 +30,13 @@ type AlertProvider struct {
 
 // IsValid returns whether the provider's configuration is valid
 func (provider *AlertProvider) IsValid() bool {
-	groups := make(map[string]int)
+	registeredGroups := make(map[string]bool)
 	if provider.Integrations != nil {
 		for _, integration := range provider.Integrations {
-			if _, present := groups[integration.Group]; present || integration.Group == "" || len(integration.IntegrationKey) != 32 {
+			if isAlreadyRegistered := registeredGroups[integration.Group]; isAlreadyRegistered || integration.Group == "" || len(integration.IntegrationKey) != 32 {
 				return false
 			}
-			groups[integration.Group] = 1
+			registeredGroups[integration.Group] = true
 		}
 	}
 	return len(provider.IntegrationKey) == 32 || provider.Integrations != nil

--- a/alerting/provider/pagerduty/pagerduty_test.go
+++ b/alerting/provider/pagerduty/pagerduty_test.go
@@ -10,12 +10,50 @@ import (
 	"github.com/TwinProduction/gatus/core"
 )
 
-func TestAlertProvider_IsValid(t *testing.T) {
+func TestAlertDefaultProvider_IsValid(t *testing.T) {
 	invalidProvider := AlertProvider{IntegrationKey: ""}
 	if invalidProvider.IsValid() {
 		t.Error("provider shouldn't have been valid")
 	}
 	validProvider := AlertProvider{IntegrationKey: "00000000000000000000000000000000"}
+	if !validProvider.IsValid() {
+		t.Error("provider should've been valid")
+	}
+}
+func TestAlertPerGroupProvider_IsValid(t *testing.T) {
+	invalidGroup := Integrations{
+		IntegrationKey: "00000000000000000000000000000000",
+		Group:          "",
+	}
+	integrations := []Integrations{}
+	integrations = append(integrations, invalidGroup)
+	invalidProviderGroupNameError := AlertProvider{
+		Integrations: integrations,
+	}
+	if invalidProviderGroupNameError.IsValid() {
+		t.Error("provider Group shouldn't have been valid")
+	}
+	invalidIntegrationKey := Integrations{
+		IntegrationKey: "",
+		Group:          "group",
+	}
+	integrations = []Integrations{}
+	integrations = append(integrations, invalidIntegrationKey)
+	invalidProviderIntegrationKey := AlertProvider{
+		Integrations: integrations,
+	}
+	if invalidProviderIntegrationKey.IsValid() {
+		t.Error("provider integration key shouldn't have been valid")
+	}
+	validIntegration := Integrations{
+		IntegrationKey: "00000000000000000000000000000000",
+		Group:          "group",
+	}
+	integrations = []Integrations{}
+	integrations = append(integrations, validIntegration)
+	validProvider := AlertProvider{
+		Integrations: integrations,
+	}
 	if !validProvider.IsValid() {
 		t.Error("provider should've been valid")
 	}
@@ -43,8 +81,70 @@ func TestAlertProvider_ToCustomAlertProviderWithResolvedAlert(t *testing.T) {
 	}
 }
 
+func TestAlertPerGroupProvider_ToCustomAlertProviderWithResolvedAlert(t *testing.T) {
+	validIntegration := Integrations{
+		IntegrationKey: "00000000000000000000000000000000",
+		Group:          "group",
+	}
+	integrations := []Integrations{}
+	integrations = append(integrations, validIntegration)
+	provider := AlertProvider{
+		IntegrationKey: "",
+		Integrations:   integrations,
+	}
+	customAlertProvider := provider.ToCustomAlertProvider(&core.Service{}, &alert.Alert{}, &core.Result{}, true)
+	if customAlertProvider == nil {
+		t.Fatal("customAlertProvider shouldn't have been nil")
+	}
+	if !strings.Contains(customAlertProvider.Body, "RESOLVED") {
+		t.Error("customAlertProvider.Body should've contained the substring RESOLVED")
+	}
+	if customAlertProvider.URL != "https://events.pagerduty.com/v2/enqueue" {
+		t.Errorf("expected URL to be %s, got %s", "https://events.pagerduty.com/v2/enqueue", customAlertProvider.URL)
+	}
+	if customAlertProvider.Method != http.MethodPost {
+		t.Errorf("expected method to be %s, got %s", http.MethodPost, customAlertProvider.Method)
+	}
+	body := make(map[string]interface{})
+	err := json.Unmarshal([]byte(customAlertProvider.Body), &body)
+	if err != nil {
+		t.Error("expected body to be valid JSON, got error:", err.Error())
+	}
+}
+
 func TestAlertProvider_ToCustomAlertProviderWithTriggeredAlert(t *testing.T) {
 	provider := AlertProvider{IntegrationKey: "00000000000000000000000000000000"}
+	customAlertProvider := provider.ToCustomAlertProvider(&core.Service{}, &alert.Alert{}, &core.Result{}, false)
+	if customAlertProvider == nil {
+		t.Fatal("customAlertProvider shouldn't have been nil")
+	}
+	if !strings.Contains(customAlertProvider.Body, "TRIGGERED") {
+		t.Error("customAlertProvider.Body should've contained the substring TRIGGERED")
+	}
+	if customAlertProvider.URL != "https://events.pagerduty.com/v2/enqueue" {
+		t.Errorf("expected URL to be %s, got %s", "https://events.pagerduty.com/v2/enqueue", customAlertProvider.URL)
+	}
+	if customAlertProvider.Method != http.MethodPost {
+		t.Errorf("expected method to be %s, got %s", http.MethodPost, customAlertProvider.Method)
+	}
+	body := make(map[string]interface{})
+	err := json.Unmarshal([]byte(customAlertProvider.Body), &body)
+	if err != nil {
+		t.Error("expected body to be valid JSON, got error:", err.Error())
+	}
+}
+
+func TestAlertPerGroupProvider_ToCustomAlertProviderWithTriggeredAlert(t *testing.T) {
+	validIntegration := Integrations{
+		IntegrationKey: "00000000000000000000000000000000",
+		Group:          "group",
+	}
+	integrations := []Integrations{}
+	integrations = append(integrations, validIntegration)
+	provider := AlertProvider{
+		IntegrationKey: "",
+		Integrations:   integrations,
+	}
 	customAlertProvider := provider.ToCustomAlertProvider(&core.Service{}, &alert.Alert{}, &core.Result{}, false)
 	if customAlertProvider == nil {
 		t.Fatal("customAlertProvider shouldn't have been nil")


### PR DESCRIPTION
## What this is doing ?

Provides support for paging multiple teams based on the `group` selector while keeping backward compatibility to the old pagerduty configuration manifest 

-  integration per team can be specified in the integrations sections in an array form.

```yaml
alerting:
  pagerduty: 
    integration-key: "00000000000000000000000000000000"
    integrations:
      - integration-key: "00000000000000000000000000000000"
        group: "team"
```

behavior:
- team integration have priority over the general integration (old pagerduty configuration)
- if no team integration is provided it will defaults to the general pagerduty integration 
- if no team integration and no general integration were provided it defaults to the first team integration provided
